### PR TITLE
Immutable events

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -1,6 +1,7 @@
 package auditrail
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/google/uuid"
@@ -10,6 +11,14 @@ import (
 //
 // This struct is not safe for concurrent write access.
 type Entry struct {
+	data *entryData
+}
+
+// entryData represents the data of an audit log event.
+//
+// This struct exists to avoid direct access to the fields of the Entry struct
+// and enforce the immutability of the log entry.
+type entryData struct {
 	// IdempotencyID is used to uniquely identify the log entry, it used as
 	// deduplication key when streaming logs to a log aggregator.
 	IdempotencyID string `json:"idempotency_id,omitempty"`
@@ -54,56 +63,118 @@ type Entry struct {
 //     [Entry.WithIdempotency] to override it to a different value.
 func NewEntry(actor, action, module string) *Entry {
 	return &Entry{
-		IdempotencyID: uuid.NewString(),
-		Actor:         actor,
-		Action:        action,
-		Module:        module,
-		OccurredAt:    time.Now(),
+		data: &entryData{
+			IdempotencyID: uuid.NewString(),
+			Actor:         actor,
+			Action:        action,
+			Module:        module,
+			OccurredAt:    time.Now(),
+		},
 	}
 }
 
 // WithIdempotency sets the idempotency ID of the event.
 func (e *Entry) WithIdempotency(idempotencyID string) *Entry {
-	e.IdempotencyID = idempotencyID
+	e.data.IdempotencyID = idempotencyID
 
 	return e
 }
 
 // WithCorrelation sets the correlation ID of the event.
 func (e *Entry) WithCorrelation(correlationID string) *Entry {
-	e.CorrelationID = correlationID
+	e.data.CorrelationID = correlationID
 
 	return e
 }
 
 // WithCausation sets the causation ID of the event.
 func (e *Entry) WithCausation(causationID string) *Entry {
-	e.CausationID = causationID
+	e.data.CausationID = causationID
 
 	return e
 }
 
 // WithAuthMethod sets the authentication method of the event.
 func (e *Entry) WithAuthMethod(method string) *Entry {
-	e.AuthMethod = method
+	e.data.AuthMethod = method
 
 	return e
 }
 
 // AppendDetails adds a key-value pair to the details of the event.
 func (e *Entry) AppendDetails(key string, value interface{}) *Entry {
-	if e.Details == nil {
-		e.Details = make(map[string]interface{})
+	if e.data.Details == nil {
+		e.data.Details = make(map[string]interface{})
 	}
 
-	e.Details[key] = value
+	e.data.Details[key] = value
 
 	return e
 }
 
 // WithOccurredAt overrides the time of the event with the given time.
 func (e *Entry) WithOccurredAt(when time.Time) *Entry {
-	e.OccurredAt = when
+	e.data.OccurredAt = when
 
 	return e
+}
+
+// GetIdempotencyID returns the idempotency ID of the event.
+func (e *Entry) GetIdempotencyID() string {
+	return e.data.IdempotencyID
+}
+
+// GetActor returns the actor of the event.
+func (e *Entry) GetActor() string {
+	return e.data.Actor
+}
+
+// GetAction returns the action of the event.
+func (e *Entry) GetAction() string {
+	return e.data.Action
+}
+
+// GetModule returns the module of the event.
+func (e *Entry) GetModule() string {
+	return e.data.Module
+}
+
+// GetCorrelationID returns the correlation ID of the event.
+func (e *Entry) GetCorrelationID() string {
+	return e.data.CorrelationID
+}
+
+// GetCausationID returns the causation ID of the event.
+func (e *Entry) GetCausationID() string {
+	return e.data.CausationID
+}
+
+// GetAuthMethod returns the authentication method of the event.
+func (e *Entry) GetAuthMethod() string {
+	return e.data.AuthMethod
+}
+
+// GetDetails returns the details of the event.
+func (e *Entry) GetDetails() map[string]interface{} {
+	cp := make(map[string]interface{})
+	for k, v := range e.data.Details {
+		cp[k] = v
+	}
+
+	return cp
+}
+
+// GetOccurredAt returns the time of the event.
+func (e *Entry) GetOccurredAt() time.Time {
+	return e.data.OccurredAt
+}
+
+// MarshalJSON marshals the log entry to JSON.
+func (e *Entry) MarshalJSON() ([]byte, error) {
+	return json.Marshal(e.data)
+}
+
+// UnmarshalJSON unmarshals the log entry from JSON.
+func (e *Entry) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &e.data)
 }

--- a/httpd/decorator_test.go
+++ b/httpd/decorator_test.go
@@ -38,12 +38,15 @@ func TestDecorator(t *testing.T) {
 	require.Equal(t, 100, logger.Size())
 
 	for _, log := range logger.Trail() {
-		require.NotEmpty(t, log.Details["http"])
-		require.NotEmpty(t, log.Details["http"].(httpd.Details))
+		details := log.GetDetails()
+
+		require.NotEmpty(t, details["http"])
+		require.IsType(t, httpd.Details{}, details["http"])
 
 		s, err := json.Marshal(log)
-		require.NoError(t, err)
 
-		println(string(s))
+		require.NoError(t, err)
+		require.NotEmpty(t, string(s))
+		require.NotEqual(t, "{}", string(s))
 	}
 }

--- a/logger_es.go
+++ b/logger_es.go
@@ -44,7 +44,7 @@ func (e *elasticLogger) Log(ctx context.Context, entry *Entry) error {
 		e.index,
 		strings.NewReader(string(body)),
 		e.client.Index.WithContext(ctx),
-		e.client.Index.WithDocumentID(entry.IdempotencyID),
+		e.client.Index.WithDocumentID(entry.GetIdempotencyID()),
 	)
 
 	return err

--- a/logger_kinesis.go
+++ b/logger_kinesis.go
@@ -48,7 +48,7 @@ func (l *kinesisLogger) Log(ctx context.Context, entry *Entry) error {
 
 	_, err = l.client.PutRecord(ctx, &kinesis.PutRecordInput{
 		Data:         append(log, '\n'),
-		PartitionKey: aws.String(entry.Module),
+		PartitionKey: aws.String(entry.GetModule()),
 		StreamName:   &l.streamName,
 	})
 

--- a/logger_kinesis_test.go
+++ b/logger_kinesis_test.go
@@ -27,13 +27,13 @@ func TestKinesisLogger(t *testing.T) {
 			n := 100
 
 			for i := 0; i < n; i++ {
-				entry := &auditrail.Entry{
-					Actor:      gofakeit.UUID(),
-					AuthMethod: gofakeit.UUID(),
-					Action:     gofakeit.Emoji(),
-					Module:     gofakeit.Emoji(),
-					OccurredAt: time.Now(),
-				}
+				entry := auditrail.NewEntry(
+					gofakeit.UUID(),
+					gofakeit.Emoji(),
+					gofakeit.Emoji(),
+				).
+					WithAuthMethod(gofakeit.UUID()).
+					WithOccurredAt(time.Now())
 
 				require.NoError(t, logger.Log(ctx, entry))
 			}


### PR DESCRIPTION
- Entry struct now has all its members unexported, this enforces the usage of provided constructor functions and mutators to avoid broken events.